### PR TITLE
Added pkg_path key with PLATFORM_ARCH variable

### DIFF
--- a/IDEA-IU/IDEA-IU.pkg.recipe
+++ b/IDEA-IU/IDEA-IU.pkg.recipe
@@ -20,6 +20,11 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%PLATFORM_ARCH%-%version%.pkg</string>
+			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>


### PR DESCRIPTION
Trying to add the arch to the final pkg name in order to distinguish different arch pkgs